### PR TITLE
chore: Add flaky test marker for failing downloads

### DIFF
--- a/tests/population/test_approximation.py
+++ b/tests/population/test_approximation.py
@@ -10,7 +10,10 @@ from superblockify.population.approximation import (
     get_edge_population,
 )
 
+from tests.conftest import mark_xfail_flaky_download
 
+
+@mark_xfail_flaky_download
 def test_add_edge_population(test_city_small_copy):
     """Test the `add_edge_population` function by design."""
     _, graph = test_city_small_copy

--- a/tests/population/test_ghsl.py
+++ b/tests/population/test_ghsl.py
@@ -11,7 +11,10 @@ from numpy import ndarray
 from superblockify.config import Config
 from superblockify.population import ghsl
 
+from tests.conftest import mark_xfail_flaky_download
 
+
+@mark_xfail_flaky_download
 @pytest.mark.parametrize(
     "resample_factor, no_window",
     [
@@ -40,6 +43,7 @@ def test_resample_load_window_gdf(resample_factor, no_window, test_one_city_copy
     assert isinstance(res_affine, Affine)
 
 
+@mark_xfail_flaky_download
 @pytest.mark.parametrize("window", [True, False, 1, 1.0, "test"])
 def test_resample_load_window_gdf_wrong_type(window, test_one_city_copy):
     """Test loading and resampling a gdf window with wrong type."""
@@ -179,6 +183,7 @@ base_path = (
 )
 
 
+@mark_xfail_flaky_download
 @pytest.mark.parametrize(
     "urls",
     [
@@ -226,6 +231,7 @@ def test_download_ghsl_invalid_urls(url, save_dir):
         ghsl.download_ghsl(base_path + url, save_dir=save_dir)
 
 
+@mark_xfail_flaky_download
 def test_download_ghsl_create_save_dir(_delete_ghsl_tifs):
     """Test the download_ghsl function with non-existent save_dir."""
     url = base_path + (


### PR DESCRIPTION
## Description

This PR adds decorators to mark tests as xfail if they are failing due to failing downloads. When testing we request the GHSL download which might fail if sending many tests. Dues to this scheduled tests were failing.

The test marker `@mark_xfail_flaky_download` already exists, so this PR only adds it to further tests which need it.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [x] 🧹 Code refactor (no functional changes)
- [ ] ✅ Test update

## How Has This Been Tested?

To be tested in CI

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally