### PR TITLE
feat: Added multiple tiles support in `get_edge_population`

### DIFF
--- a/superblockify/population/approximation.py
+++ b/superblockify/population/approximation.py
@@ -6,8 +6,7 @@ See reference notebook for a detailed description of the population approximatio
 from functools import partial
 from multiprocessing import Pool
 
-import pandas as pd
-import geopandas as gpd
+from pandas import concat
 from geopandas import GeoDataFrame
 from numpy import float32, sum as npsum, zeros
 from rasterio import open as rasopen
@@ -157,7 +156,7 @@ def _load_ghsl_multifile(ghsl_files, bbox_moll):
 
     # Combine all GeoDataFrames while preserving CRS and geometry
     ghsl_polygons_combined = GeoDataFrame(
-        pd.concat(ghsl_polygons_list, ignore_index=True),
+        concat(ghsl_polygons_list, ignore_index=True),
         crs="World Mollweide",
         geometry="geometry"
     )
@@ -231,7 +230,7 @@ def get_edge_population(graph, batch_size=10000, **tess_kwargs):
     bbox_moll = edge_cells.union_all().buffer(100).bounds
     ghsl_file = get_ghsl(bbox_moll)
 
-    # Checking if ghsl_file is a list of multiple tile files. See Issue #124.
+    # Checking if ghsl_file is a list of multiple tile files. 
     if isinstance(ghsl_file, list):
         ghsl_polygons = _load_ghsl_multifile(ghsl_file, bbox_moll)
     else:

--- a/superblockify/population/approximation.py
+++ b/superblockify/population/approximation.py
@@ -6,6 +6,8 @@ See reference notebook for a detailed description of the population approximatio
 from functools import partial
 from multiprocessing import Pool
 
+import pandas as pd
+import geopandas as gpd
 from geopandas import GeoDataFrame
 from numpy import float32, sum as npsum, zeros
 from rasterio import open as rasopen
@@ -124,6 +126,50 @@ def get_population_area(graph):
     return npsum(population), npsum(area)
 
 
+def _load_ghsl_multifile(ghsl_files, bbox_moll):
+    """Load and concatenate GHSL polygons from multiple tile files.
+
+    Parameters
+    ----------
+    ghsl_files : list
+        List of paths to GHSL raster tile files.
+    bbox_moll : tuple
+        Bounding box (minx, miny, maxx, maxy) in World Mollweide coordinates.
+
+    Returns
+    -------
+    geopandas.GeoDataFrame
+        Combined GeoDataFrame with polygons from all tiles.
+
+    Notes
+    -----
+    See Issue #124.
+    """
+    ghsl_polygons_list = []
+
+    for ghsl_file in ghsl_files:
+        logger.debug("Loading GHSL polygons from tile: %s", ghsl_file)
+        with rasopen(ghsl_file) as src:
+            load_window = src.window(*bbox_moll)
+        # Load polygons from the windowed region of this tile
+        ghsl_polygons = load_ghsl_as_polygons(ghsl_file, window=load_window)
+        ghsl_polygons_list.append(ghsl_polygons)
+
+    # Combine all GeoDataFrames while preserving CRS and geometry
+    ghsl_polygons_combined = GeoDataFrame(
+        pd.concat(ghsl_polygons_list, ignore_index=True),
+        crs="World Mollweide",
+        geometry="geometry"
+    )
+
+    logger.debug(
+        "Loaded %d polygons from %d GHSL tiles.",
+        len(ghsl_polygons_combined),
+        len(ghsl_files)
+    )
+    return ghsl_polygons_combined
+
+
 def get_edge_population(graph, batch_size=10000, **tess_kwargs):
     """Get edge population for the graph.
 
@@ -185,10 +231,13 @@ def get_edge_population(graph, batch_size=10000, **tess_kwargs):
     bbox_moll = edge_cells.union_all().buffer(100).bounds
     ghsl_file = get_ghsl(bbox_moll)
 
-    with rasopen(ghsl_file) as src:
-        load_window = src.window(*bbox_moll)
-
-    ghsl_polygons = load_ghsl_as_polygons(ghsl_file, window=load_window)
+    # Checking if ghsl_file is a list of multiple tile files. See Issue #124.
+    if isinstance(ghsl_file, list):
+        ghsl_polygons = _load_ghsl_multifile(ghsl_file, bbox_moll)
+    else:
+        with rasopen(ghsl_file) as src:
+            load_window = src.window(*bbox_moll)
+        ghsl_polygons = load_ghsl_as_polygons(ghsl_file, window=load_window)
     # Build STRtree index
     logger.debug("Building STRtree index.")
     ghsl_polygons_index = STRtree(ghsl_polygons.geometry)

--- a/tests/population/test_approximation.py
+++ b/tests/population/test_approximation.py
@@ -3,11 +3,12 @@
 import pytest
 from networkx import ego_graph
 from numpy import float32
-
+from osmnx import graph_from_point, project_graph
 from superblockify.population.approximation import (
     add_edge_population,
     get_population_area,
     get_edge_population,
+    _load_ghsl_multifile,
 )
 
 from tests.conftest import mark_xfail_flaky_download
@@ -65,3 +66,29 @@ def test_get_edge_population_faulty_batch_size(test_city_small_copy, batch_size)
     _, graph = test_city_small_copy
     with pytest.raises(ValueError):
         get_edge_population(graph, batch_size=batch_size)
+
+
+@pytest.mark.parametrize("lat,lon,dist,city_name", [
+    (41.8956456, 12.4655397, 500, "Rome"),
+    (8.098238, -76.729070, 200, "Turbo"),
+])
+@mark_xfail_flaky_download
+def test_get_edge_population_multiple_tiles(lat, lon, dist, city_name):
+    """Test that get_edge_population handles multiple GHSL tiles. Issue #124.
+    """
+    graph = graph_from_point(
+        (lat, lon), 
+        dist=dist, 
+        network_type='drive', 
+        simplify=True
+    )
+    graph = project_graph(graph)
+    
+    add_edge_population(graph, overwrite=True)
+        
+    # Check all edges have the `population` and `area` attributes
+    for _, _, data in graph.edges(data=True):
+        assert isinstance(data["population"], float32)
+        assert isinstance(data["area"], float32)
+        assert isinstance(data["cell_id"], int)
+


### PR DESCRIPTION
## Description

Adds a function to handle multiple GHSL tile files when the study area spans across more than one tile.

Small change to the code in `get_edge_population`


## Related Issue


Fixes #124

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🧹 Code refactor (no functional changes)
- [ ] ✅ Test update

## How Has This Been Tested?



- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

I used the same minimal example in Rome
```
import osmnx as ox
from superblockify.population.approximation import add_edge_population
import geopandas as gpd

boundary_lat, boundary_lon = 41.8956456, 12.4655397

graph = ox.graph_from_point(
    (boundary_lat, boundary_lon), 
    dist=500, 
    network_type='drive', 
    simplify=True
)

graph = ox.project_graph(graph)

add_edge_population(graph, overwrite=True)

```

## Screenshots (if applicable)

<img width="2993" height="1092" alt="image" src="https://github.com/user-attachments/assets/b933ecf5-4ba7-462f-85e9-a2418f7f8985" />


## Checklist

- [ ] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally


## Additional Notes


